### PR TITLE
Update spring cloud version to Finchley.SR4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<spring-cloud.version>Finchley.BUILD-SNAPSHOT</spring-cloud.version>
+		<spring-cloud.version>Finchley.SR4</spring-cloud.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Finchley.BUILD-SNAPSHOT  is no longer available, and the eureka server cannot start due to a dependency error.

The error is 

```shell
$ eureka-server master ./mvnw spring-boot:run
/Users/pierodibello/Documents/workspace/Java/eureka-server
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] Non-resolvable import POM: Could not find artifact org.springframework.cloud:spring-cloud-dependencies:pom:Finchley.BUILD-SNAPSHOT @ line 36, column 16
[ERROR] 'dependencies.dependency.version' for org.springframework.cloud:spring-cloud-starter-netflix-eureka-server:jar is missing. @ line 28, column 15
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project com.pdincau:eureka-server:0.0.1-SNAPSHOT (/Users/pierodibello/Documents/workspace/Java/eureka-server/pom.xml) has 2 errors
[ERROR]     Non-resolvable import POM: Could not find artifact org.springframework.cloud:spring-cloud-dependencies:pom:Finchley.BUILD-SNAPSHOT @ line 36, column 16 -> [Help 2]
[ERROR]     'dependencies.dependency.version' for org.springframework.cloud:spring-cloud-starter-netflix-eureka-server:jar is missing. @ line 28, column 15
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```
